### PR TITLE
Check type of "array" before assuming it has length

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,11 +199,11 @@
             }
 
             case MANY: {
-                var arr = new Array(value.length);
-
                 if (!Array.isArray(value)) {
                     return err(expected('an array', value));
                 }
+                
+                var arr = new Array(value.length);
 
                 for (var i=0; i<value.length; i++) {
                     var result = decodeInternal(decoder.child, value[i]);


### PR DESCRIPTION
if value==null `value.length()` will fail. But the Array.isArray(value) check would prevent it and show a nicer error message

The thrown error also allows the use of optional `Dec.optional(null, Dec.many(Dec.integer))` which did not work before